### PR TITLE
[finishes #164349264] enables admin to edit office and save

### DIFF
--- a/UI/scripts/create_office.js
+++ b/UI/scripts/create_office.js
@@ -59,21 +59,21 @@ function createOffice(e) {
 
 }
 
-// function loadOffices() {
-//     if (localStorage.isEdit == 'true') {
-//         document.getElementById('name').value = localStorage.office_name;
-//         console.log(localStorage.office_name)
-//         var textToFind = localStorage.office_type;
-//         var dd = document.getElementById('officeTypeList');
-//         for (var i = 0; i < dd.options.length; i++) {
-//             if (dd.options[i].text === textToFind) {
-//                 dd.selectedIndex = i;
-//                 break;
-//             }
-//         }
+function loadOffices() {
+    if (localStorage.isEdit == 'true') {
+        document.getElementById('name').value = localStorage.office_name;
+        console.log(localStorage.office_name)
+        var textToFind = localStorage.office_type;
+        var dd = document.getElementById('officeTypeList');
+        for (var i = 0; i < dd.options.length; i++) {
+            if (dd.options[i].text === textToFind) {
+                dd.selectedIndex = i;
+                break;
+            }
+        }
 
 
-//         document.getElementById("title").innerText = "UPDATE OFFICE"
+        document.getElementById("title").innerText = "UPDATE OFFICE"
 
-//     }
-// }
+    }
+}

--- a/UI/scripts/offices.js
+++ b/UI/scripts/offices.js
@@ -52,29 +52,29 @@ function getOffices() {
 }
 
 
-// function getOffice(office_id) {
-//     fetch("https://vast-mountain-54945.herokuapp.com/api/v2/offices/" + office_id, {
-//         method: 'GET',
-//         headers: new Headers({
-//             'Content-Type': 'application/json',
-//             'token': localStorage.auth
-//         })
-//     })
-//         .then((res) => {
-//             return res.json()
-//         })
-//         .then(function (office) {
+function getOffice(office_id) {
+    fetch("https://vast-mountain-54945.herokuapp.com/api/v2/offices/" + office_id, {
+        method: 'GET',
+        headers: new Headers({
+            'Content-Type': 'application/json',
+            'token': localStorage.auth
+        })
+    })
+        .then((res) => {
+            return res.json()
+        })
+        .then(function (office) {
 
-//             localStorage.isEdit = new Boolean(true)
-//             localStorage.office_name = office['data'][0]['name']
-//             localStorage.office_type = office['data'][0]['office_type']
-//             localStorage.office_id = office['data'][0]['office_id']
+            localStorage.isEdit = new Boolean(true)
+            localStorage.office_name = office['data'][0]['name']
+            localStorage.office_type = office['data'][0]['office_type']
+            localStorage.office_id = office['data'][0]['office_id']
 
-//             window.location = "https://kelvin-otieno.github.io/politico/UI/create_office.html"
+            window.location = "https://kelvin-otieno.github.io/politico/UI/create_office.html"
 
 
-//         })
-// }
+        })
+}
 
 // function deleteOffice(office_id) {
 //     answer = confirm('Sure to delete office?')


### PR DESCRIPTION
#### What does this PR do?
Enables admins to edit political offices and save
#### Description of Task to be completed?

- Create an edit button in the offices page
- Add click event on the button which opens create_office page in edit mode
- Allow saving of the edited data

#### How should this be manually tested?

- Visit the offices page. [Offices](https://kelvin-otieno.github.io/politico/UI/offices.html)
- Click the edit button to edit the specific office
- Save the edited data
- Visit the offices page again to confirm

#### What are the relevant pivotal tracker stories?
[#164349264](https://www.pivotaltracker.com/n/projects/2241865)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/18186076/53678472-a32cd800-3cd0-11e9-998b-4833a611bf46.png)
![image](https://user-images.githubusercontent.com/18186076/53678482-c9527800-3cd0-11e9-82d6-9b5cfa9e342c.png)
![image](https://user-images.githubusercontent.com/18186076/53678486-d40d0d00-3cd0-11e9-884e-935deadcd5dd.png)
![image](https://user-images.githubusercontent.com/18186076/53678490-dff8cf00-3cd0-11e9-917a-8ab45f8362c1.png)
![image](https://user-images.githubusercontent.com/18186076/53678494-f141db80-3cd0-11e9-867e-764e4ddc10d2.png)
